### PR TITLE
included the correlation in the sentiment.ipynb file

### DIFF
--- a/notebooks/sentiment_analysis.ipynb
+++ b/notebooks/sentiment_analysis.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,10 +42,10 @@
      "text": [
       "[nltk_data] Downloading package punkt to\n",
       "[nltk_data]     C:\\Users\\Admin\\AppData\\Roaming\\nltk_data...\n",
-      "[nltk_data]   Unzipping tokenizers\\punkt.zip.\n",
+      "[nltk_data]   Package punkt is already up-to-date!\n",
       "[nltk_data] Downloading package stopwords to\n",
       "[nltk_data]     C:\\Users\\Admin\\AppData\\Roaming\\nltk_data...\n",
-      "[nltk_data]   Unzipping corpora\\stopwords.zip.\n"
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
      ]
     },
     {
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Reduced news data size to include only companies present in the financial data files. Performed sentiment analysis on the relevant news headlines. Merged financial data for 7 companies and converted the date to a pandas datetime format, separating date and time. Merged the news and financial data based on date alignment. Calculated correlation and visualized the results with a heatmap.